### PR TITLE
Make qmk target before ensuring dependencies installed

### DIFF
--- a/.github/workflows/keymaps.yml
+++ b/.github/workflows/keymaps.yml
@@ -27,7 +27,7 @@ jobs:
 
       - run: echo "${GITHUB_WORKSPACE}/bin" >> $GITHUB_PATH
 
-      - run: make keymaps
+      - run: make qmk
 
       - run: cd $QMK_HOME && sudo util/qmk_install.sh -y
 


### PR DESCRIPTION
Reduces the amount of time needed before ensuring qmk dependencies are installed using script.